### PR TITLE
Remove Deimos-specific Rake Task skip

### DIFF
--- a/lib/fig_tree.rb
+++ b/lib/fig_tree.rb
@@ -224,13 +224,6 @@ module FigTree
 
     # Configure the settings with values.
     def configure(&block)
-      if defined?(Rake) && defined?(Rake.application)
-        tasks = Rake.application.top_level_tasks
-        if tasks.any? { |t| %w(assets webpacker yarn).include?(t.split(':').first) }
-          puts 'Skipping Deimos configuration since we are in JS/CSS compilation'
-          return
-        end
-      end
       config.run_callbacks(:configure) do
         config.instance_eval(&block)
       end


### PR DESCRIPTION
When running `configure`, Fig Tree will skip the block entirely is we're running a "pre-compilation" step. It also exits with a message that is specific to Deimos, which is a bit odd for a generic configuration gem.

Of course we could fix that message, but we found that this "skip" is actually hurting us. If Deimos configuration doesn't run, some Schema classes don't get loaded, and when Assets Precompilation loads the rest of our code, it'll exit with an error saying it can't find the Schema classes referenced by other parts of the code.

I believe this kind of skip should be added by individual projects, rather than Fig Tree or Deimos, as it can be quite project-specific